### PR TITLE
Change VoteRepository.Vote() method name to .SaveVote()

### DIFF
--- a/PlutoDAO.Gov.Application/Votes/IVoteRepository.cs
+++ b/PlutoDAO.Gov.Application/Votes/IVoteRepository.cs
@@ -6,6 +6,6 @@ namespace PlutoDAO.Gov.Application.Votes
     public interface IVoteRepository
     {
         public Task<string> GetVoteIntent(ValidatedVote validatedVote, Proposal proposal, string proposalId);
-        public Task Vote(ValidatedVote validatedVote, Proposal proposal, string proposalId, string voterPrivateKey);
+        public Task SaveVote(ValidatedVote validatedVote, Proposal proposal, string proposalId, string voterPrivateKey);
     }
 }

--- a/PlutoDAO.Gov.Application/Votes/VoteService.cs
+++ b/PlutoDAO.Gov.Application/Votes/VoteService.cs
@@ -25,7 +25,7 @@ namespace PlutoDAO.Gov.Application.Votes
                 var vote = new Vote(request.Voter, (Option) request.Option, (Asset) request.Asset,
                     request.Amount);
                 var validatedVote = proposal.CastVote(vote);
-                await _voteRepository.Vote(validatedVote, proposal, proposalId, request.PrivateKey);
+                await _voteRepository.SaveVote(validatedVote, proposal, proposalId, request.PrivateKey);
             }
             catch (Exception e)
             {

--- a/PlutoDAO.Gov.Infrastructure/Stellar/Votes/VoteRepository.cs
+++ b/PlutoDAO.Gov.Infrastructure/Stellar/Votes/VoteRepository.cs
@@ -25,7 +25,7 @@ namespace PlutoDAO.Gov.Infrastructure.Stellar.Votes
             return voteTransaction.ToUnsignedEnvelopeXdrBase64();
         }
 
-        public async Task Vote(ValidatedVote validatedVote, Proposal proposal, string proposalId, string voterPrivateKey)
+        public async Task SaveVote(ValidatedVote validatedVote, Proposal proposal, string proposalId, string voterPrivateKey)
         {
             var voterKeyPair = KeyPair.FromSecretSeed(voterPrivateKey);
             var voteTransaction = await GetVoteTransaction(validatedVote, proposal, proposalId);


### PR DESCRIPTION
Chaged the method name VoteRepository.Vote() to .SaveVote() to reflect that voting is not responsibility of the Repository but of the Domain layer.

Implements https://trello.com/c/diLQz8eq/114-cambiar-metodo-voterepositoryvote-por-voterepositorysavevote