### PR TITLE
Add RemainingMinutes attribute to ProposalIdentifier response

### DIFF
--- a/PlutoDAO.Gov.Application/Proposals/Responses/IProposalIdentifier.cs
+++ b/PlutoDAO.Gov.Application/Proposals/Responses/IProposalIdentifier.cs
@@ -4,5 +4,6 @@ namespace PlutoDAO.Gov.Application.Proposals.Responses
     {
         public string Id { get; set; }
         public string Name { get; set; }
+        public float RemainingMinutes { get; set; }
     }
 }

--- a/PlutoDAO.Gov.Application/Proposals/Responses/ProposalIdentifier.cs
+++ b/PlutoDAO.Gov.Application/Proposals/Responses/ProposalIdentifier.cs
@@ -4,5 +4,6 @@ namespace PlutoDAO.Gov.Application.Proposals.Responses
     {
         public string Id { get; set; }
         public string Name { get; set; }
+        public float RemainingMinutes { get; set; }
     }
 }

--- a/PlutoDAO.Gov.Infrastructure/Stellar/Proposals/ProposalRepository.cs
+++ b/PlutoDAO.Gov.Infrastructure/Stellar/Proposals/ProposalRepository.cs
@@ -153,7 +153,11 @@ namespace PlutoDAO.Gov.Infrastructure.Stellar.Proposals
                         .First()
                         .AssetCode;
 
-                    proposalList.Add(new ProposalIdentifier {Id = assetCode, Name = record.MemoValue});
+                    var proposalClosingDay = DateTime.Parse(record.CreatedAt).AddDays(31).Date;
+                    var minutesUntilProposalClosing = (float) (proposalClosingDay - DateTime.Now).TotalMinutes;
+
+                    proposalList.Add(new ProposalIdentifier
+                        {Id = assetCode, Name = record.MemoValue, RemainingMinutes = minutesUntilProposalClosing});
                 }
 
             return proposalList.ToArray();

--- a/PlutoDAO.Gov.Test.Integration/Controllers/_1GetProposalTestController.cs
+++ b/PlutoDAO.Gov.Test.Integration/Controllers/_1GetProposalTestController.cs
@@ -55,6 +55,8 @@ namespace PlutoDAO.Gov.Test.Integration.Controllers
             Assert.Equal(6, proposalList.Length);
             Assert.Equal("Proposal2NameTest", proposalList[4].Name);
             Assert.Equal("Proposal3NameTest", proposalList[5].Name);
+            Assert.True(proposalList[4].RemainingMinutes > 0);
+            Assert.True(proposalList[5].RemainingMinutes > 0);
         }
     }
 }


### PR DESCRIPTION
Added a field to ProposalIdentifier response that accounts for the minutes remaining until proposal closing.

Implements https://trello.com/c/nKzszTg8/136-como-un-usuario-quiero-ver-cuanto-tiempo-restante-hay-para-votar-en-la-pagina-de-listado-de-propuestas